### PR TITLE
Add function to validate request via signing_key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__/
 
 # Mac
 .DS_Store
+
+# Local Testing Payloads
+local/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Slack Bot for managing Team Fines running on the Serverless framework
 
     `serverless deploy`
 
-- Run lambda function locally:
+- Run lambda function locally with JSON event payload:
 
-    `serverless invoke local --function fine`
+    `serverless invoke local --function fine --path event.json`

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,30 @@
+import os
+import time
+import hashlib
+import hmac
+
+HEADER_SLACK_TIMESTAMP = 'X-Slack-Request-Timestamp'
+HEADER_SLACK_SIGNATURE = 'X-Slack-Signature'
+BYTES_ENCODING = 'latin-1'
+
+def isVerifiedRequest(event):
+    slack_signing_secret = os.environ['SLACK_SIGNING_SECRET']
+    signature = event['headers'][HEADER_SLACK_SIGNATURE]
+    timestamp = event['headers'][HEADER_SLACK_TIMESTAMP]
+
+    if abs(time.time() - int(timestamp)) > 60 * 5:
+        print('Replay attack check failed. Time out by 5+ minutes')
+        return False
+
+    calculated_basestring = 'v0:{}:{}'.format(timestamp, event['body'])
+    calculated_signature = 'v0=' + hmac.new(
+        bytes(slack_signing_secret, BYTES_ENCODING),
+        msg = bytes(calculated_basestring, BYTES_ENCODING),
+        digestmod = hashlib.sha256
+    ).hexdigest()
+
+    if not hmac.compare_digest(signature, calculated_signature):
+        print('Invalid signature. Does not match X-Slack-Signature')
+        return False
+
+    return True

--- a/fine.py
+++ b/fine.py
@@ -1,14 +1,15 @@
-import json
-import urllib.parse
+from urllib.parse import parse_qs
+from auth import isVerifiedRequest
 
 def handle(event, context):
-    print(event['body'])
-    params = parse_qs(event['body'])
+    if not isVerifiedRequest(event):
+        return { "statusCode": 401 }
 
+    params = parse_qs(event['body'])
     text = params['text'][0]
     user_name = params['user_name'][0]
 
     print('Text -> ', text)
     print('User Name -> ', user_name)
-
     return { "statusCode": 200 }
+

--- a/fines.py
+++ b/fines.py
@@ -1,6 +1,7 @@
-import json
-import urllib.parse
+from auth import isVerifiedRequest
 
 def handle(event, context):
-    print(event)
+    if not isVerifiedRequest(event):
+        return { "statusCode": 401 }
+    print("Valid Fines request")
     return { "statusCode": 200 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,8 @@ functions:
       - http:
           path: fine
           method: post
+    environment:
+      SLACK_SIGNING_SECRET: ${ssm:/fined/SLACK_SIGNING_SECRET~true}
   fines:
     handler: fines.handle
     description: List all user fines
@@ -24,4 +26,6 @@ functions:
       - http:
           path: fines
           method: post
+    environment:
+      SLACK_SIGNING_SECRET: ${ssm:/fined/SLACK_SIGNING_SECRET~true}
       


### PR DESCRIPTION
- Use SLACK_SIGNING_SECRET in SSM parameter store
- Validate using https://api.slack.com/docs/verifying-requests-from-slack info
- Check both HMAC and timestamp (for replay attacks)