### PR TITLE
Dynamo db abstraction

### DIFF
--- a/dynamo.py
+++ b/dynamo.py
@@ -1,9 +1,13 @@
 import os
 import boto3
+from boto3.dynamodb.types import TypeDeserializer
+
+AWS_REGION = 'us-east-1'
+DYNAMO_ENV_KEY = 'DYNAMODB_TABLE'
 
 def update_item(team_id, user_name, text):
-    dynamodb = boto3.client('dynamodb', region_name='us-east-1')
-    table_name = os.environ['DYNAMODB_TABLE']
+    dynamodb = boto3.client('dynamodb', region_name=AWS_REGION)
+    table_name = os.environ[DYNAMO_ENV_KEY]
     dynamodb.update_item(
         TableName=table_name,
         Key={'teamId': {'S': team_id}},
@@ -15,9 +19,15 @@ def update_item(team_id, user_name, text):
     )
 
 def get_item(team_id):
-    dynamodb = boto3.client('dynamodb', region_name='us-east-1')
-    table_name = os.environ['DYNAMODB_TABLE']
-    return dynamodb.get_item(
+    dynamodb = boto3.client('dynamodb', region_name=AWS_REGION)
+    table_name = os.environ[DYNAMO_ENV_KEY]
+    dynamo_response = dynamodb.get_item(
         TableName=table_name,
         Key={'teamId': {'S': team_id}}
     )
+
+    if (dynamo_response.get('Item') is None or dynamo_response['Item']['teamFines'] is None):
+        return None
+
+    team_fines = dynamo_response['Item']['teamFines']
+    return TypeDeserializer().deserialize(team_fines)

--- a/fine.py
+++ b/fine.py
@@ -1,14 +1,14 @@
 import re
 from urllib.parse import parse_qs
-from auth import is_verified_request
-from dynamo import update_item
+import auth
 import response
+import dynamo
 
 HELP_REGEX = r'help'
 FINE_REGEX = r'@.*\$.*for.*'
 
 def handle(event, _):
-    if not is_verified_request(event):
+    if not auth.is_verified_request(event):
         return {'statusCode': 401}
 
     params = parse_qs(event['body'])
@@ -29,5 +29,6 @@ def handle_fine_request(params):
     user_name = params['user_name'][0]
     team_id = params['team_id'][0]
 
-    update_item(team_id, user_name, text)
+    dynamo.update_item(team_id, user_name, text)
     return response.create_fine_response(user_name)
+    

--- a/fines.py
+++ b/fines.py
@@ -1,28 +1,24 @@
 from urllib.parse import parse_qs
-from boto3.dynamodb.types import TypeDeserializer
-from auth import is_verified_request
-from dynamo import get_item
+import auth
+import dynamo
 import response
 
 def handle(event, _):
-    if not is_verified_request(event):
+    if not auth.is_verified_request(event):
         return {"statusCode": 401}
 
     params = parse_qs(event['body'])
     team_id = params['team_id'][0]
-    dynamo_response = get_item(team_id)
+    team_fines = dynamo.get_item(team_id)
 
-    if (dynamo_response.get('Item') is None or dynamo_response['Item']['teamFines'] is None):
+    if team_fines is None:
         return response.create_no_fines_response()
 
-    team_fines = dynamo_response['Item']['teamFines']
-    team_fines_deserialized = from_dynamodb_to_json(team_fines)
-    body = response.create_fines_response(team_fines_deserialized)
+    team_fines_formatted = format_team_fines(team_fines)
+    body = response.create_fines_response(team_fines_formatted)
     return response.wrap_response_body(body)
 
-def from_dynamodb_to_json(item):
-    d = TypeDeserializer()
-    items = d.deserialize(item)
-    items = [x['text'] for x in items]
-    items = "\n \u2022 ".join(items)
-    return items
+def format_team_fines(fines):
+    fines = [x['text'] for x in fines]
+    fines = "\n \u2022 ".join(fines)
+    return fines

--- a/local/fine.json
+++ b/local/fine.json
@@ -3,7 +3,7 @@
     "path": "/fine",
     "httpMethod": "POST",
     "headers": {
-      "X-Slack-Signature": "v0=e157fce587b5434d07463583c49b0cb0df097280c4abde8a629dda9e3ddd6798",
+      "X-Slack-Signature": "v0=05cce2d818ef80afba956b65851f221d911f7db8a81874a7ff8fc4213a197ebc",
       "X-Slack-Request-Timestamp": "1582354237"
     },
     "body": "token=PLAZDD9GlbmE9Ard7vo1td72&team_id=fake_team_id&team_domain=cbeardsmore&channel_id=DQFL9F0GH&channel_name=directmessage&user_id=UQPJ3CFG8&user_name=user1&command=%2Ffine&text=no&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FTQPJASJUD%2F848397789159%2F2ZQ6lroVdI6rPARbAgdpIGHw&trigger_id=838611962625.839622902965.64f1f6eb51f0f7731ceec2b59a3388cb",


### PR DESCRIPTION
- Abstract the DynamoDB boto calls into a seperate file
- This will allow us easily MOCK out dynamo db in testing a little easier
- Dynamo logic in python isn't too easily so good to contain this and keep /fine and /fines logic pretty simple